### PR TITLE
Gcc8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "imgui.cpp" "imgui_draw.cpp" "imgui_demo.cpp" "imgui_widgets.cpp"
+                       INCLUDE_DIRS "."
+                       )

--- a/misc/softraster/texture.h
+++ b/misc/softraster/texture.h
@@ -3,6 +3,7 @@
 
 #include "color.h"
 #include "defines.h"
+#include <stdio.h>
 
 enum class texture_type_t
 {

--- a/misc/softraster/utils.h
+++ b/misc/softraster/utils.h
@@ -5,6 +5,7 @@
 #  pragma GCC optimize("-03")
 #endif
 
+#include <cmath>
 #include "defines.h"
 
 template<typename T>
@@ -55,9 +56,9 @@ template<typename T>
 inline void swap(T *tri1, T *tri2)
 {
   T temp;
-//   memcpy(&temp, tri1, sizeof(T));
-//   memcpy(tri1, tri2, sizeof(T));
-//   memcpy(tri2, &temp, sizeof(T));
+  memcpy(static_cast<void*>(&temp), tri1, sizeof(T));
+  memcpy(static_cast<void*>(tri1), tri2, sizeof(T));
+  memcpy(static_cast<void*>(tri2), &temp, sizeof(T));
 }
 
 // [0x00, 0xFF]

--- a/misc/softraster/utils.h
+++ b/misc/softraster/utils.h
@@ -55,9 +55,9 @@ template<typename T>
 inline void swap(T *tri1, T *tri2)
 {
   T temp;
-  memcpy(&temp, tri1, sizeof(T));
-  memcpy(tri1, tri2, sizeof(T));
-  memcpy(tri2, &temp, sizeof(T));
+//   memcpy(&temp, tri1, sizeof(T));
+//   memcpy(tri1, tri2, sizeof(T));
+//   memcpy(tri2, &temp, sizeof(T));
 }
 
 // [0x00, 0xFF]


### PR DESCRIPTION
This does two things:

Adds a CMake file to allow ESP-IDF v4.2 (and probably others) to use this as a component.

And then it fixes some compilation errors that GCC 8 (used by IDF v4.2) complains about.

ESP-IDF v3.3 ignores the CMake file, and its GCC 5.3.0 works fine, still, too. So this maintains backwards compatibility.